### PR TITLE
refactor: update default checkmk_server_version from 2.0.0p26 to v2.0.0p27 :arrow_up:

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -100,7 +100,7 @@ this is often shown as `my-site` in the CheckMK documentation examples.
 [source,yaml]
 ----
 checkmk_server_download_checksum: [OS-specific, see /defaults directory]
-checkmk_server_version: "2.0.0p26"
+checkmk_server_version: "2.0.0p27"
 ----
 Version of CheckMK RAW edition to install.
 

--- a/README.orig.adoc
+++ b/README.orig.adoc
@@ -79,7 +79,7 @@ this is often shown as `my-site` in the CheckMK documentation examples.
 [source,yaml]
 ----
 checkmk_server_download_checksum: [OS-specific, see /defaults directory]
-checkmk_server_version: "2.0.0p26"
+checkmk_server_version: "2.0.0p27"
 ----
 Version of CheckMK RAW edition to install.
 

--- a/__scripts/check_new_version.py
+++ b/__scripts/check_new_version.py
@@ -37,7 +37,9 @@ def main() -> None:
     current_checkmk_server_version = args.checkmk_server_version
 
     if current_checkmk_server_version is None:
-        current_defaults_yml = yaml.safe_load(Path("defaults/main.yml").read_text(encoding="utf8"))
+        current_defaults_yml = yaml.safe_load(
+            Path("defaults/main.yml").read_text(encoding="utf8")
+        )
         current_checkmk_server_version = current_defaults_yml["checkmk_server_version"]
 
     tags_since = get_checkmk_raw_tags_since(current_checkmk_server_version, github_api)

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -7,6 +7,7 @@ import getpass
 import json
 import os
 import platform
+import shutil
 from html import escape
 from pathlib import Path
 from time import sleep
@@ -441,6 +442,7 @@ def main() -> None:
         "JonasPammer/ansible-role-checkmk_agent"
     )
     agent_repo_path: Path = server_repo_path.joinpath("__scripts", agent_repo.name)
+    shutil.rmtree(agent_repo_path)
     agent_local_git_branch_before = clone_repo_and_checkout_branch(
         agent_repo, agent_repo_path, AGENT_MASTER_BRANCH
     )

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -114,6 +114,7 @@ def clone_repo_and_checkout_branch(
             "we were previously on..."
         )
         execute(["git", "checkout", _git_branch_before], repo_path)
+    atexit.register(atexit_handler)
 
     return _git_branch_before, atexit_handler
 

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -454,13 +454,13 @@ def main() -> None:
     ) = clone_repo_and_checkout_branch(agent_repo, agent_repo_path, AGENT_MASTER_BRANCH)
 
     server_defaults_yml: Path = server_repo_path.joinpath("defaults/main.yml")
-    current_checkmk_server_version = yaml.safe_load(server_defaults_yml.read_text(encoding="utf8"))[
-        "checkmk_server_version"
-    ]
+    current_checkmk_server_version = yaml.safe_load(
+        server_defaults_yml.read_text(encoding="utf8")
+    )["checkmk_server_version"]
     agent_defaults_yml: Path = agent_repo_path.joinpath("defaults/main.yml")
-    current_checkmk_agent_version = yaml.safe_load(agent_defaults_yml.read_text(encoding="utf8"))[
-        "checkmk_agent_version"
-    ]
+    current_checkmk_agent_version = yaml.safe_load(
+        agent_defaults_yml.read_text(encoding="utf8")
+    )["checkmk_agent_version"]
 
     if current_checkmk_server_version != current_checkmk_agent_version:
         logger.fatal(

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -446,7 +446,8 @@ def main() -> None:
         "JonasPammer/ansible-role-checkmk_agent"
     )
     agent_repo_path: Path = server_repo_path.joinpath("__scripts", agent_repo.name)
-    shutil.rmtree(agent_repo_path)
+    if agent_repo_path.exists():
+        shutil.rmtree(agent_repo_path)
     (
         agent_local_git_branch_before,
         agent_atexit_handler,

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -515,17 +515,17 @@ def main() -> None:
         server_repo,
         SERVER_MASTER_BRANCH,
         repo_other=agent_repo,
-        new_version=next_checkmk_server_version,
-        new_tag=next_server_role_tag_version,
-        new_tag_other=next_agent_role_tag_version,
+        new_version=next_checkmk_server_version.name,
+        new_tag=str(next_server_role_tag_version),
+        new_tag_other=str(next_agent_role_tag_version),
     )
     next_agent_role_tag_create_url: str = get_prefilled_new_release_url(
         agent_repo,
         AGENT_MASTER_BRANCH,
         repo_other=server_repo,
-        new_version=next_checkmk_server_version,
-        new_tag=next_agent_role_tag_version,
-        new_tag_other=next_server_role_tag_version,
+        new_version=next_checkmk_server_version.name,
+        new_tag=str(next_agent_role_tag_version),
+        new_tag_other=str(next_server_role_tag_version),
     )
 
     if latest_released_checkmk_server_version != current_checkmk_server_version:

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -510,7 +510,7 @@ def main() -> None:
     )["checkmk_agent_version"]
 
     next_server_role_tag_version: VersionInfo = server_role_tags[0][1].bump_patch()
-    next_agent_role_tag_version: VersionInfo = server_role_tags[0][1].bump_patch()
+    next_agent_role_tag_version: VersionInfo = agent_role_tags[0][1].bump_patch()
     next_server_role_tag_create_url: str = get_prefilled_new_release_url(
         server_repo,
         SERVER_MASTER_BRANCH,

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -176,7 +176,7 @@ def create_or_update_missing_release_issue(
         "\n\n"
         "Automated Version Updating is halted until a new version is released. "
         "For convenience you can use the following link to create a new release: \n"
-        f"{next_role_tag_create_url}"
+        f"> {next_role_tag_create_url}"
     )
     ISSUE_BODY = GENERAL_BODY + BODY_TIP
     logger.error(ISSUE_BODY)
@@ -590,13 +590,13 @@ def main() -> None:
         f"from {current_checkmk_server_version} "
         f"to {next_checkmk_server_version.name} :arrow_up:"
     )
-    SERVER_PR_NOTE1 = _PR_NOTE1_BASE + "\n" + next_server_role_tag_create_url
+    SERVER_PR_NOTE1 = _PR_NOTE1_BASE + "\n> " + next_server_role_tag_create_url
     AGENT_COMMIT_TITLE: str = (
         "refactor: update default checkmk_agent_version "
         f"from {current_checkmk_agent_version} "
         f"to {next_checkmk_server_version.name} :arrow_up:"
     )
-    AGENT_PR_NOTE1 = _PR_NOTE1_BASE + "\n" + next_agent_role_tag_create_url
+    AGENT_PR_NOTE1 = _PR_NOTE1_BASE + "\n> " + next_agent_role_tag_create_url
     SERVER_PR_BODY: str = (
         f"{SCRIPT_MSG} \n\n {COMMIT_DESCRIPTION} \n\n" f"{SERVER_PR_NOTE1} {PR_NOTE2}"
     )

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -26,7 +26,7 @@ from github.Repository import Repository
 from github.Tag import Tag
 from semver import VersionInfo
 
-from .utils import add_argparse_silent_option
+from .utils import add_argparse_silent_option, on_rm_error
 from .utils import add_argparse_verbosity_option
 from .utils import console
 from .utils import execute
@@ -447,7 +447,7 @@ def main() -> None:
     )
     agent_repo_path: Path = server_repo_path.joinpath("__scripts", agent_repo.name)
     if agent_repo_path.exists():
-        shutil.rmtree(agent_repo_path)
+        shutil.rmtree(agent_repo_path, onerror=on_rm_error)
     (
         agent_local_git_branch_before,
         agent_atexit_handler,

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -140,7 +140,7 @@ def get_prefilled_new_release_url(
 def close_missing_release_issues(
     repo: Repository, latest_released_role_tag: Tag, current_checkmk_version: str
 ):
-    for issue in repo.get_issues(state=open):
+    for issue in repo.get_issues(state="open"):
         if FIND_MISSING_RELEASE_BASE_TITLE not in issue.title:
             continue
         logger.info(

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -114,6 +114,7 @@ def clone_repo_and_checkout_branch(
             "we were previously on..."
         )
         execute(["git", "checkout", _git_branch_before], repo_path)
+
     atexit.register(atexit_handler)
 
     return _git_branch_before, atexit_handler

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -36,7 +36,9 @@ from .utils import init_logger
 from .utils import logger
 from .utils import replace_text_between
 
-SERVER_MASTER_BRANCH: str = "master"
+SERVER_MASTER_BRANCH: str = (
+    "15-ci-extend-cipy-with-nicety-link-to-create-new-minor-release"
+)
 SERVER_PR_BRANCH: str = "checkmk_server_version-autoupdate"
 AGENT_MASTER_BRANCH: str = "master"
 AGENT_PR_BRANCH: str = "checkmk_agent_version-autoupdate"

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -175,7 +175,7 @@ def create_or_update_missing_release_issue(
     BODY_TIP = (
         "\n\n"
         "Automated Version Updating is halted until a new version is released. "
-        "For convenience you can use the following link to create a new release: "
+        "For convenience you can use the following link to create a new release: \n"
         f"{next_role_tag_create_url}"
     )
     ISSUE_BODY = GENERAL_BODY + BODY_TIP
@@ -590,13 +590,13 @@ def main() -> None:
         f"from {current_checkmk_server_version} "
         f"to {next_checkmk_server_version.name} :arrow_up:"
     )
-    SERVER_PR_NOTE1 = _PR_NOTE1_BASE + next_server_role_tag_create_url
+    SERVER_PR_NOTE1 = _PR_NOTE1_BASE + "\n" + next_server_role_tag_create_url
     AGENT_COMMIT_TITLE: str = (
         "refactor: update default checkmk_agent_version "
         f"from {current_checkmk_agent_version} "
         f"to {next_checkmk_server_version.name} :arrow_up:"
     )
-    AGENT_PR_NOTE1 = _PR_NOTE1_BASE + next_agent_role_tag_create_url
+    AGENT_PR_NOTE1 = _PR_NOTE1_BASE + "\n" + next_agent_role_tag_create_url
     SERVER_PR_BODY: str = (
         f"{SCRIPT_MSG} \n\n {COMMIT_DESCRIPTION} \n\n" f"{SERVER_PR_NOTE1} {PR_NOTE2}"
     )

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -497,8 +497,9 @@ def main() -> None:
             "defaults/main.yml", ref=server_role_tags[0][0].commit.sha
         ).decoded_content
     )["checkmk_server_version"]
+
     latest_released_checkmk_agent_version: str = yaml.safe_load(
-        server_repo.get_contents(
+        agent_repo.get_contents(
             "defaults/main.yml", ref=agent_role_tags[0][0].commit.sha
         ).decoded_content
     )["checkmk_agent_version"]

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -76,7 +76,7 @@ def unidiff_output(expected: str, actual: str):
 
 def clone_repo_and_checkout_branch(
     repo: Repository, repo_path: Path, branch: str
-) -> str:
+) -> tuple[str, Callable[..., object]]:
     if not repo_path.joinpath(".git").exists():
         execute(["git", "clone", repo.clone_url], repo_path.parent)
     if "AUTO_UPDATE_PAT" in os.environ:
@@ -105,7 +105,16 @@ def clone_repo_and_checkout_branch(
     if _git_branch_before != branch:
         execute(["git", "fetch"], repo_path)
         execute(["git", "checkout", branch], repo_path)
-    return _git_branch_before
+
+    def atexit_handler() -> None:
+        logger.notice(
+            "The program terminated unexpectedly! "
+            f"Checking out the {repo_path.name} branch "
+            "we were previously on..."
+        )
+        execute(["git", "checkout", _git_branch_before], repo_path)
+
+    return _git_branch_before, atexit_handler
 
 
 def get_prefilled_new_release_url(
@@ -233,15 +242,7 @@ def create_or_update_missing_release_issue(
 
 def checkout_pristine_pr_branch(
     repo_path: Path, pr_branch: str, before_branch: str, files: list[str]
-) -> Callable[..., object]:
-    def atexit_handler() -> None:
-        logger.notice(
-            "The program terminated unexpectedly! "
-            f"Checking out the {repo_path.name} branch "
-            "we were previously on..."
-        )
-        execute(["git", "checkout", before_branch], repo_path)
-
+) -> None:
     _git_status_before = execute(["git", "status", "--porcelain"], repo_path)
     if any(s in _git_status_before for s in files):
         logger.error("Working directory is not clean! Aborting...")
@@ -267,12 +268,10 @@ def checkout_pristine_pr_branch(
 
     execute(["git", "fetch"], repo_path)
     execute(["git", "checkout", pr_branch], repo_path)
-    atexit.register(atexit_handler)
 
     execute(["git", "reset"], repo_path)
     for f in files:
         execute(["git", "checkout", "HEAD", "--", f], repo_path)
-    return atexit_handler
 
 
 def commit_push_and_checkout_before(
@@ -436,7 +435,10 @@ def main() -> None:
         "JonasPammer/ansible-role-checkmk_server"
     )
     server_repo_path: Path = Path.cwd()
-    server_local_git_branch_before = clone_repo_and_checkout_branch(
+    (
+        server_local_git_branch_before,
+        server_atexit_handler,
+    ) = clone_repo_and_checkout_branch(
         server_repo, server_repo_path, SERVER_MASTER_BRANCH
     )
 
@@ -445,9 +447,10 @@ def main() -> None:
     )
     agent_repo_path: Path = server_repo_path.joinpath("__scripts", agent_repo.name)
     shutil.rmtree(agent_repo_path)
-    agent_local_git_branch_before = clone_repo_and_checkout_branch(
-        agent_repo, agent_repo_path, AGENT_MASTER_BRANCH
-    )
+    (
+        agent_local_git_branch_before,
+        agent_atexit_handler,
+    ) = clone_repo_and_checkout_branch(agent_repo, agent_repo_path, AGENT_MASTER_BRANCH)
 
     server_defaults_yml: Path = server_repo_path.joinpath("defaults/main.yml")
     current_checkmk_server_version = yaml.safe_load(server_defaults_yml.read_text(encoding="utf8"))[
@@ -601,7 +604,7 @@ def main() -> None:
         f"{SCRIPT_MSG} \n\n {COMMIT_DESCRIPTION} \n\n" f"{AGENT_PR_NOTE1} {PR_NOTE2}"
     )
 
-    server_atexit_handler = checkout_pristine_pr_branch(
+    checkout_pristine_pr_branch(
         repo_path=server_repo_path,
         pr_branch=SERVER_PR_BRANCH,
         before_branch=server_local_git_branch_before,
@@ -620,7 +623,7 @@ def main() -> None:
         description=COMMIT_DESCRIPTION,
     )
 
-    agent_atexit_handler = checkout_pristine_pr_branch(
+    checkout_pristine_pr_branch(
         repo_path=agent_repo_path,
         pr_branch=AGENT_PR_BRANCH,
         before_branch=agent_local_git_branch_before,

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -509,8 +509,8 @@ def main() -> None:
         ).decoded_content
     )["checkmk_agent_version"]
 
-    next_server_role_tag_version: VersionInfo = server_role_tags[0][1].bump_minor()
-    next_agent_role_tag_version: VersionInfo = server_role_tags[0][1].bump_minor()
+    next_server_role_tag_version: VersionInfo = server_role_tags[0][1].bump_patch()
+    next_agent_role_tag_version: VersionInfo = server_role_tags[0][1].bump_patch()
     next_server_role_tag_create_url: str = get_prefilled_new_release_url(
         server_repo,
         SERVER_MASTER_BRANCH,

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -26,7 +26,7 @@ from github.Repository import Repository
 from github.Tag import Tag
 from semver import VersionInfo
 
-from .utils import add_argparse_silent_option, on_rm_error
+from .utils import add_argparse_silent_option
 from .utils import add_argparse_verbosity_option
 from .utils import console
 from .utils import execute
@@ -34,6 +34,7 @@ from .utils import generate_yaml
 from .utils import get_checkmk_raw_tags_since
 from .utils import init_logger
 from .utils import logger
+from .utils import on_rm_error
 from .utils import replace_text_between
 
 SERVER_MASTER_BRANCH: str = (

--- a/__scripts/requirements.in
+++ b/__scripts/requirements.in
@@ -1,5 +1,6 @@
 PyGitHub>=1,<2
 pyyaml
 rich
+semver
 types-PyYAML
 verboselogs

--- a/__scripts/requirements.txt
+++ b/__scripts/requirements.txt
@@ -32,6 +32,8 @@ requests==2.28.1
     # via pygithub
 rich==12.5.1
     # via -r __scripts/requirements.in
+semver==2.13.0
+    # via -r __scripts/requirements.in
 types-pyyaml==6.0.11
     # via -r __scripts/requirements.in
 typing-extensions==4.3.0

--- a/__scripts/utils.py
+++ b/__scripts/utils.py
@@ -361,6 +361,6 @@ def execute(
 
 
 def on_rm_error(func, path, exc_info):
-    #from: https://stackoverflow.com/questions/4829043/how-to-remove-read-only-attrib-directory-with-python-in-windows
+    # from: https://stackoverflow.com/questions/4829043/how-to-remove-read-only-attrib-directory-with-python-in-windows
     os.chmod(path, stat.S_IWRITE)
     os.unlink(path)

--- a/__scripts/utils.py
+++ b/__scripts/utils.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import os
 import pathlib
+import stat
 import subprocess
 from argparse import ArgumentParser
 from functools import lru_cache
@@ -357,3 +358,9 @@ def execute(
             f"See above for more information."
         )
         raise ex
+
+
+def on_rm_error(func, path, exc_info):
+    #from: https://stackoverflow.com/questions/4829043/how-to-remove-read-only-attrib-directory-with-python-in-windows
+    os.chmod(path, stat.S_IWRITE)
+    os.unlink(path)

--- a/__scripts/utils.py
+++ b/__scripts/utils.py
@@ -361,6 +361,6 @@ def execute(
 
 
 def on_rm_error(func, path, exc_info):
-    # from: https://stackoverflow.com/questions/4829043/how-to-remove-read-only-attrib-directory-with-python-in-windows
+    # from https://stackoverflow.com/a/4829285
     os.chmod(path, stat.S_IWRITE)
     os.unlink(path)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,18 +19,18 @@ checkmk_server_install_cache_valid_time: "3600"
 # ===== BEGIN generate_yaml MANAGED SECTION
 
 _checkmk_server_download_checksum:
-  CentOS_7: sha1:87affa588da9c56b6a80ac425a7d4f3ab1d9028c
-  CentOS_8: sha1:cb3a4b8bf35ba6f939710cf4acfb9b7da34c1f45
-  Debian_bullseye: sha1:c896a0cdfa2a648229e160c1660a94ba445c5e50
-  Debian_buster: sha1:7213547a2f5e336b31a057ef0773f5a88ed42b0d
-  Debian_stretch: sha1:3fc6bc7f2c71dac3240b3cf2f5ec5523a4f2457d
-  Ubuntu_bionic: sha1:b08c77f31796754af0942e0100fe58675b2b8b54
-  Ubuntu_focal: sha1:cce6a669ad56c8a7cbb47a9f50ac31964fe4c96f
-  Ubuntu_hirsute: sha1:9947418875f973e2015619f7c3bedd7c7b1c393b
-  Ubuntu_impish: sha1:6995f3fd86fa894071ebef05108a30568b15a251
-  Ubuntu_jammy: sha1:03902a04795ea5a9d0a5fd71b8d933f8956a4e1e
-  Ubuntu_xenial: sha1:c5555ed1cb2dad304a07bc4a326e11d7f5349930
-checkmk_server_version: 2.0.0p26
+  CentOS_7: sha1:a5a6ebe3431f814fa24d2e9c4a6e742a408b5658
+  CentOS_8: sha1:d565f8ab19b67a2e8d62136be7ebeeb80d85e5c4
+  Debian_bullseye: sha1:8e82f2fc3692b3756b44d2a64221b754ee9eebc6
+  Debian_buster: sha1:fcca752dd4956943f92a72d492f2991e583b664a
+  Debian_stretch: sha1:0bf3ad00f06fbc591bb8908b30dd8cdba0f2dd33
+  Ubuntu_bionic: sha1:8de78553aa1933ff7b7ca4d0594d07550ff29316
+  Ubuntu_focal: sha1:9334d58a775db6db4cc31bcdc13c97adae0add18
+  Ubuntu_hirsute: sha1:468b16647ec3262f761279b22db3f22031f321be
+  Ubuntu_impish: sha1:9db1330d8654bb2071d2cf1fae0d2a6c4d6635a9
+  Ubuntu_jammy: sha1:a4a8899e83828aef985ae8e212ec9448cf99852d
+  Ubuntu_xenial: sha1:fabe141626d02730d37c10058559309b17ca4507
+checkmk_server_version: 2.0.0p27
 
 # ===== END generate_yaml MANAGED SECTION
 checkmk_server_download_checksum: "{{


### PR DESCRIPTION
:robot: *Authored by `__scripts/ci.py` python script on RAZEROLEDQ4 by priva from Vienna*  

 *Release Date of v2.0.0p27: 2022-07-19*
*GitHub Compare URL (for the interested):* https://github.com/tribe29/checkmk/compare/v2.0.0p26...v2.0.0p27

 

**This PR should result in the release of a new minor version for this role**! For convenience you can use the following link to create a new release: 
> https://github.com/JonasPammer/ansible-role-checkmk_server/releases/new?tag=2.0.3&target=15-ci-extend-cipy-with-nicety-link-to-create-new-minor-release&title=update%20default%20to%20v2.0.0p27&body=Accompanying%20%60ansible-role-checkmk_agent%60%20release%3A%20%5B1.0.2%5D%28https%3A%2F%2Fgithub.com%2FJonasPammer%2Fansible-role-checkmk_server%2Freleases%2Ftag%2F1.0.2%29 

NOTE: There have been **12** new versions since 2.0.0p26. After this PR has been merged, the github workflow will run again and a new PR will open semi-immideally. Please ensure to create a proper tag/release for **every** merged ci.py PR.

---
Accompanying `ansible-role-checkmk_agent` PR: https://github.com/JonasPammer/ansible-role-checkmk_agent/pull/9