### PR TITLE
ci: extend ci.py to abort, close and notify on missing release

### DIFF
--- a/.github/workflows/check-new-version.yml
+++ b/.github/workflows/check-new-version.yml
@@ -9,6 +9,8 @@ name: Check for new CheckMK Version
       - ".github/workflows/check-new-version.yml"
       # as per __scripts/ci.py
       - "defaults/main.yml"
+    tags:
+      - "*"
   schedule:
     # At 05:00 on Sunday.
     - cron: "0 5 * * 0"

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -542,6 +542,7 @@ def main() -> None:
         new_tag_other=str(next_server_role_tag_version),
     )
 
+    _exit: bool = False
     if latest_released_checkmk_server_version != current_checkmk_server_version:
         create_or_update_missing_release_issue(
             server_repo,
@@ -550,7 +551,7 @@ def main() -> None:
             current_checkmk_version=current_checkmk_server_version,
             next_role_tag_create_url=next_server_role_tag_create_url,
         )
-        exit(1)
+        _exit = True
     else:
         close_missing_release_issues(
             server_repo,
@@ -573,6 +574,9 @@ def main() -> None:
             agent_role_tags[0][0],
             current_checkmk_agent_version,
         )
+    if _exit:
+        exit(1)
+    del _exit
 
     _PR_NOTE1_BASE = (
         "**This PR should result in the release of a new minor version "

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -226,6 +226,11 @@ def create_or_update_missing_release_issue(
                 break  # file loop
 
     for pr in open_version_change_prs:
+        logger.info(
+            f"Closing {pr} of {repo} as the default checkmk version "
+            f"in the latest role release does not match the current version! "
+            f"May reopen again when {found_issue.html_url} is resolved. "
+        )
         labels: list[Label | str] = pr.labels
         if not any("do-not-merge" == str(label) for label in labels):
             try:

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -174,7 +174,7 @@ def create_or_update_missing_release_issue(
         "\n\n"
         "Automated Version Updating is halted until a new version is released. "
         "For convenience you can use the following link to create a new release: \n"
-        f"{next_role_tag_create_url}"
+        f"> {next_role_tag_create_url}"
     )
     ISSUE_BODY = GENERAL_BODY + BODY_TIP
     logger.error(ISSUE_BODY)
@@ -588,13 +588,13 @@ def main() -> None:
         f"from {current_checkmk_server_version} "
         f"to {next_checkmk_server_version.name} :arrow_up:"
     )
-    SERVER_PR_NOTE1 = _PR_NOTE1_BASE + "\n" + next_server_role_tag_create_url
+    SERVER_PR_NOTE1 = _PR_NOTE1_BASE + "\n> " + next_server_role_tag_create_url
     AGENT_COMMIT_TITLE: str = (
         "refactor: update default checkmk_agent_version "
         f"from {current_checkmk_agent_version} "
         f"to {next_checkmk_server_version.name} :arrow_up:"
     )
-    AGENT_PR_NOTE1 = _PR_NOTE1_BASE + "\n" + next_agent_role_tag_create_url
+    AGENT_PR_NOTE1 = _PR_NOTE1_BASE + "\n> " + next_agent_role_tag_create_url
     SERVER_PR_BODY: str = (
         f"{SCRIPT_MSG} \n\n {COMMIT_DESCRIPTION} \n\n" f"{SERVER_PR_NOTE1} {PR_NOTE2}"
     )

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -444,7 +444,8 @@ def main() -> None:
         "JonasPammer/ansible-role-checkmk_agent"
     )
     agent_repo_path: Path = server_repo_path.joinpath("__scripts", agent_repo.name)
-    shutil.rmtree(agent_repo_path)
+    if agent_repo_path.exists():
+        shutil.rmtree(agent_repo_path)
     (
         agent_local_git_branch_before,
         agent_atexit_handler,

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -7,6 +7,7 @@ import getpass
 import json
 import os
 import platform
+import shutil
 from html import escape
 from pathlib import Path
 from time import sleep
@@ -441,6 +442,7 @@ def main() -> None:
         "JonasPammer/ansible-role-checkmk_agent"
     )
     agent_repo_path: Path = server_repo_path.joinpath("__scripts", agent_repo.name)
+    shutil.rmtree(agent_repo_path)
     agent_local_git_branch_before = clone_repo_and_checkout_branch(
         agent_repo, agent_repo_path, AGENT_MASTER_BRANCH
     )

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -507,8 +507,8 @@ def main() -> None:
         ).decoded_content
     )["checkmk_agent_version"]
 
-    next_server_role_tag_version: VersionInfo = server_role_tags[0][1].bump_minor()
-    next_agent_role_tag_version: VersionInfo = server_role_tags[0][1].bump_minor()
+    next_server_role_tag_version: VersionInfo = server_role_tags[0][1].bump_patch()
+    next_agent_role_tag_version: VersionInfo = server_role_tags[0][1].bump_patch()
     next_server_role_tag_create_url: str = get_prefilled_new_release_url(
         server_repo,
         SERVER_MASTER_BRANCH,

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -26,7 +26,7 @@ from github.Repository import Repository
 from github.Tag import Tag
 from semver import VersionInfo
 
-from .utils import add_argparse_silent_option, on_rm_error
+from .utils import add_argparse_silent_option
 from .utils import add_argparse_verbosity_option
 from .utils import console
 from .utils import execute
@@ -34,6 +34,7 @@ from .utils import generate_yaml
 from .utils import get_checkmk_raw_tags_since
 from .utils import init_logger
 from .utils import logger
+from .utils import on_rm_error
 from .utils import replace_text_between
 
 SERVER_MASTER_BRANCH: str = "master"

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -173,7 +173,7 @@ def create_or_update_missing_release_issue(
     BODY_TIP = (
         "\n\n"
         "Automated Version Updating is halted until a new version is released. "
-        "For convenience you can use the following link to create a new release: "
+        "For convenience you can use the following link to create a new release: \n"
         f"{next_role_tag_create_url}"
     )
     ISSUE_BODY = GENERAL_BODY + BODY_TIP
@@ -588,13 +588,13 @@ def main() -> None:
         f"from {current_checkmk_server_version} "
         f"to {next_checkmk_server_version.name} :arrow_up:"
     )
-    SERVER_PR_NOTE1 = _PR_NOTE1_BASE + next_server_role_tag_create_url
+    SERVER_PR_NOTE1 = _PR_NOTE1_BASE + "\n" + next_server_role_tag_create_url
     AGENT_COMMIT_TITLE: str = (
         "refactor: update default checkmk_agent_version "
         f"from {current_checkmk_agent_version} "
         f"to {next_checkmk_server_version.name} :arrow_up:"
     )
-    AGENT_PR_NOTE1 = _PR_NOTE1_BASE + next_agent_role_tag_create_url
+    AGENT_PR_NOTE1 = _PR_NOTE1_BASE + "\n" + next_agent_role_tag_create_url
     SERVER_PR_BODY: str = (
         f"{SCRIPT_MSG} \n\n {COMMIT_DESCRIPTION} \n\n" f"{SERVER_PR_NOTE1} {PR_NOTE2}"
     )

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -112,6 +112,7 @@ def clone_repo_and_checkout_branch(
             "we were previously on..."
         )
         execute(["git", "checkout", _git_branch_before], repo_path)
+
     atexit.register(atexit_handler)
 
     return _git_branch_before, atexit_handler

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -476,6 +476,7 @@ def main() -> None:
     )["checkmk_agent_version"]
 
     if current_checkmk_server_version != current_checkmk_agent_version:
+        # TODO this should create an issue tbh
         logger.fatal(
             "Version mismatch between current checkmk_server_version "
             "and checkmk_agent_version!! Aborting, please fix.."

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -508,7 +508,7 @@ def main() -> None:
     )["checkmk_agent_version"]
 
     next_server_role_tag_version: VersionInfo = server_role_tags[0][1].bump_patch()
-    next_agent_role_tag_version: VersionInfo = server_role_tags[0][1].bump_patch()
+    next_agent_role_tag_version: VersionInfo = agent_role_tags[0][1].bump_patch()
     next_server_role_tag_create_url: str = get_prefilled_new_release_url(
         server_repo,
         SERVER_MASTER_BRANCH,

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -218,9 +218,12 @@ def create_or_update_missing_release_issue(
     __issue_params = {"title": ACTUAL_ISSUE_TITLE, "body": ISSUE_BODY}
     if found_issue is None:
         if not dry_run:
-            logger.info(f"Creating 'missing release issue' {__issue_params}")
             found_issue = repo.create_issue(
                 *__issue_params, assignee=repo.owner, labels=[]
+            )
+            logger.info(
+                "Created 'missing release issue' "
+                f"{found_issue.html_url} ({__issue_params})"
             )
         else:
             logger.info(f"Would've created 'missing release issue' {__issue_params}")
@@ -815,12 +818,16 @@ def main() -> None:
             + unidiff_output(found_server_pr.body, SERVER_PR_BODY)
         )
         if not args.dry_run:
-            logger.info(f"Editing {found_server_pr}... {__server_pr_change_log}")
+            logger.info(
+                f"Editing {found_server_pr.html_url}... {__server_pr_change_log}"
+            )
             found_server_pr.edit(
                 title=SERVER_COMMIT_TITLE, body=SERVER_PR_BODY, state="open"
             )
         else:
-            logger.info(f"Would've edited {found_server_pr} {__server_pr_change_log}")
+            logger.info(
+                f"Would've edited {found_server_pr.html_url} {__server_pr_change_log}"
+            )
 
     if found_agent_pr is not None:
         if found_server_pr is not None:
@@ -835,12 +842,14 @@ def main() -> None:
             + unidiff_output(found_agent_pr.body, AGENT_PR_BODY)
         )
         if not args.dry_run:
-            logger.info(f"Editing {found_agent_pr}... {__agent_pr_change_log}")
+            logger.info(f"Editing {found_agent_pr.html_url}... {__agent_pr_change_log}")
             found_agent_pr.edit(
                 title=AGENT_COMMIT_TITLE, body=AGENT_PR_BODY, state="open"
             )
         else:
-            logger.info(f"Would've edited {found_agent_pr} {__agent_pr_change_log}")
+            logger.info(
+                f"Would've edited {found_agent_pr.html_url} {__agent_pr_change_log}"
+            )
 
 
 if __name__ == "__main__":

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -218,7 +218,7 @@ def create_or_update_missing_release_issue(
     for pr in repo.get_pulls():
         pr_files = pr.get_files()
         for file in filter(
-            lambda f: any(s == f.name for s in SERVER_REPO_FILES), pr_files
+            lambda f: any(s == f.filename for s in SERVER_REPO_FILES), pr_files
         ):
             if "version: " in file.patch:
                 open_version_change_prs.append(pr)

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -251,6 +251,7 @@ def create_or_update_missing_release_issue(
             f"#{found_issue.number} has been resolved! {_opt}"
             f"\n\n{SCRIPT_MSG}"
         )
+        pr.edit(state="closed")
 
 
 def checkout_pristine_pr_branch(

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -244,7 +244,6 @@ def create_or_update_missing_release_issue(
                 "once said Issue has been resolved!*"
             )
         pr.set_labels(*labels)
-        pr.edit(state="closed")
         pr.create_issue_comment(
             GENERAL_BODY + "\n\n"
             "Closing this pull request until "

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -513,17 +513,17 @@ def main() -> None:
         server_repo,
         SERVER_MASTER_BRANCH,
         repo_other=agent_repo,
-        new_version=next_checkmk_server_version,
-        new_tag=next_server_role_tag_version,
-        new_tag_other=next_agent_role_tag_version,
+        new_version=next_checkmk_server_version.name,
+        new_tag=str(next_server_role_tag_version),
+        new_tag_other=str(next_agent_role_tag_version),
     )
     next_agent_role_tag_create_url: str = get_prefilled_new_release_url(
         agent_repo,
         AGENT_MASTER_BRANCH,
         repo_other=server_repo,
-        new_version=next_checkmk_server_version,
-        new_tag=next_agent_role_tag_version,
-        new_tag_other=next_server_role_tag_version,
+        new_version=next_checkmk_server_version.name,
+        new_tag=str(next_agent_role_tag_version),
+        new_tag_other=str(next_server_role_tag_version),
     )
 
     if latest_released_checkmk_server_version != current_checkmk_server_version:

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -168,7 +168,7 @@ def create_or_update_missing_release_issue(
     GENERAL_BODY = (
         "The default checkmk version has recently been updated "
         f"from {latest_released_checkmk_version} "
-        f"(in [{latest_released_role_tag}]"
+        f"(in [{latest_released_role_tag.name}]"
         f"({latest_released_role_tag.commit.html_url})) "
         f"to {current_checkmk_version}, "
         "but no new GitHub release/tag has been created for it. "

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -180,7 +180,7 @@ def create_or_update_missing_release_issue(
         f"> {next_role_tag_create_url}"
     )
     ISSUE_BODY = GENERAL_BODY + BODY_TIP
-    logger.error(ISSUE_BODY)
+    logger.error(ISSUE_BODY.replace("\n\n", ""))
     ISSUE_BODY += f"\n\n {SCRIPT_MSG}"
 
     found_issue: Issue | None = None

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -311,6 +311,9 @@ def commit_push_and_checkout_before(
             ["git", "push", "--force", "--set-upstream", "origin", pr_branch],
             repo_path,
         )
+    # eliminate windows bug
+    for f in files:
+        execute(["git", "add", f], repo_path)
     logger.verbose(f"Checking out previous branch of {repo_path.name} again..")
     execute(["git", "checkout", before_branch], repo_path)
 

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -554,7 +554,7 @@ def main() -> None:
     else:
         close_missing_release_issues(
             server_repo,
-            latest_released_checkmk_server_version,
+            server_role_tags[0][0],
             current_checkmk_server_version,
         )
 
@@ -570,7 +570,7 @@ def main() -> None:
     else:
         close_missing_release_issues(
             server_repo,
-            latest_released_checkmk_agent_version,
+            agent_role_tags[0][0],
             current_checkmk_agent_version,
         )
 

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -570,7 +570,7 @@ def main() -> None:
         exit(1)
     else:
         close_missing_release_issues(
-            server_repo,
+            agent_repo,
             agent_role_tags[0][0],
             current_checkmk_agent_version,
         )

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -497,8 +497,9 @@ def main() -> None:
             "defaults/main.yml", ref=server_role_tags[0][0].commit.sha
         ).decoded_content
     )["checkmk_server_version"]
+
     latest_released_checkmk_agent_version: str = yaml.safe_load(
-        server_repo.get_contents(
+        agent_repo.get_contents(
             "defaults/main.yml", ref=agent_role_tags[0][0].commit.sha
         ).decoded_content
     )["checkmk_agent_version"]

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -436,7 +436,7 @@ def _get_server_change_notes(
     ]
 
     for key, checksum_new in _new_checksums.items():
-        checksum_old = _old_checksums.get(key, default=None)
+        checksum_old = _old_checksums.get(key, None)
         if checksum_new is not None and checksum_old is None:
             _retv.append(f"CheckMk Added support for {key}")
         elif checksum_new is None and checksum_old is not None:
@@ -445,7 +445,7 @@ def _get_server_change_notes(
             _retv.append(f"Added checksum for {key}")
 
     for key, checksum_old in _old_checksums.items():
-        checksum_new = _new_checksums.get(key, default="None")
+        checksum_new = _new_checksums.get(key, "None")
         if checksum_old is None and checksum_new == "None":
             _retv.append(f"Dropped support for {key} by removing checksum")
 

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -112,6 +112,7 @@ def clone_repo_and_checkout_branch(
             "we were previously on..."
         )
         execute(["git", "checkout", _git_branch_before], repo_path)
+    atexit.register(atexit_handler)
 
     return _git_branch_before, atexit_handler
 

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -484,7 +484,7 @@ def main() -> None:
     args = parser.parse_args()
     init_logger(args.verbose, args.silent)
 
-    _login_or_token = None if args.dry_run else os.environ["GITHUB_TOKEN"]
+    _login_or_token = os.environ["GITHUB_TOKEN"]
     github_api: Github = Github(_login_or_token)
 
     server_repo: Repository = github_api.get_repo(

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -184,7 +184,7 @@ def create_or_update_missing_release_issue(
     ISSUE_BODY += f"\n\n {SCRIPT_MSG}"
 
     found_issue: Issue | None = None
-    for issue in repo.get_issues(state=all):
+    for issue in repo.get_issues(state="all"):
         if (
             FIND_MISSING_RELEASE_BASE_TITLE in issue.title
             and current_checkmk_version in issue.title

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -138,7 +138,7 @@ def get_prefilled_new_release_url(
 def close_missing_release_issues(
     repo: Repository, latest_released_role_tag: Tag, current_checkmk_version: str
 ):
-    for issue in repo.get_issues(state=open):
+    for issue in repo.get_issues(state="open"):
         if FIND_MISSING_RELEASE_BASE_TITLE not in issue.title:
             continue
         logger.info(

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -311,9 +311,11 @@ def commit_push_and_checkout_before(
             ["git", "push", "--force", "--set-upstream", "origin", pr_branch],
             repo_path,
         )
+
     # eliminate windows bug
     for f in files:
         execute(["git", "add", f], repo_path)
+
     logger.verbose(f"Checking out previous branch of {repo_path.name} again..")
     execute(["git", "checkout", before_branch], repo_path)
 

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -26,7 +26,7 @@ from github.Repository import Repository
 from github.Tag import Tag
 from semver import VersionInfo
 
-from .utils import add_argparse_silent_option
+from .utils import add_argparse_silent_option, on_rm_error
 from .utils import add_argparse_verbosity_option
 from .utils import console
 from .utils import execute
@@ -445,7 +445,7 @@ def main() -> None:
     )
     agent_repo_path: Path = server_repo_path.joinpath("__scripts", agent_repo.name)
     if agent_repo_path.exists():
-        shutil.rmtree(agent_repo_path)
+        shutil.rmtree(agent_repo_path, onerror=on_rm_error)
     (
         agent_local_git_branch_before,
         agent_atexit_handler,

--- a/__scripts/requirements.in
+++ b/__scripts/requirements.in
@@ -1,5 +1,6 @@
 PyGitHub>=1,<2
 pyyaml
 rich
+semver
 types-PyYAML
 verboselogs

--- a/__scripts/requirements.txt
+++ b/__scripts/requirements.txt
@@ -32,6 +32,8 @@ requests==2.28.1
     # via pygithub
 rich==12.5.1
     # via -r __scripts/requirements.in
+semver==2.13.0
+    # via -r __scripts/requirements.in
 types-pyyaml==6.0.11
     # via -r __scripts/requirements.in
 typing-extensions==4.3.0

--- a/__scripts/utils.py
+++ b/__scripts/utils.py
@@ -363,6 +363,6 @@ def execute(
 
 
 def on_rm_error(func, path, exc_info):
-    #from: https://stackoverflow.com/questions/4829043/how-to-remove-read-only-attrib-directory-with-python-in-windows
+    # from: https://stackoverflow.com/questions/4829043/how-to-remove-read-only-attrib-directory-with-python-in-windows
     os.chmod(path, stat.S_IWRITE)
     os.unlink(path)

--- a/__scripts/utils.py
+++ b/__scripts/utils.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import os
 import pathlib
+import stat
 import subprocess
 from argparse import ArgumentParser
 from functools import lru_cache
@@ -359,3 +360,9 @@ def execute(
             f"See above for more information."
         )
         raise ex
+
+
+def on_rm_error(func, path, exc_info):
+    #from: https://stackoverflow.com/questions/4829043/how-to-remove-read-only-attrib-directory-with-python-in-windows
+    os.chmod(path, stat.S_IWRITE)
+    os.unlink(path)

--- a/__scripts/utils.py
+++ b/__scripts/utils.py
@@ -363,6 +363,6 @@ def execute(
 
 
 def on_rm_error(func, path, exc_info):
-    # from: https://stackoverflow.com/questions/4829043/how-to-remove-read-only-attrib-directory-with-python-in-windows
+    # from https://stackoverflow.com/a/4829285
     os.chmod(path, stat.S_IWRITE)
     os.unlink(path)


### PR DESCRIPTION
Also Implements and thus Closes #15 

## **Required Checklist**

- [ ] Documentation has been altered or extended appropriately
- [ ] This pull request and its commits address only a single concern
- [ ] I have followed [JonasPammer's Ansible Role Development Guidelines](https://github.com/JonasPammer/cookiecutter-ansible-role/blob/master/ROLE_DEVELOPMENT_GUIDELINES.adoc)
- [x] I am a nice guy <!-- the 'too long; did not read;' of the CODE_OF_CONDUCT.md -->

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

## _Optional_ Checklist

- [x] pre-commit was installed in local development environment (if not, a GitHub workflow will run pre-commit once you create the request)

- [x] my commits are small, single-purpose, detailed and maybe even follow the [conventional commit specification](https://github.com/JonasPammer/JonasPammer/blob/master/demystifying/conventional_commits.adoc) for extra convenience of the reviewer
