### PR TITLE
refactor: update default checkmk_server_version from 2.0.0p26 to v2.0.0p27 :arrow_up:

### DIFF
--- a/.github/workflows/check-new-version.yml
+++ b/.github/workflows/check-new-version.yml
@@ -9,6 +9,8 @@ name: Check for new CheckMK Version
       - ".github/workflows/check-new-version.yml"
       # as per __scripts/ci.py
       - "defaults/main.yml"
+    tags:
+      - "*"
   schedule:
     # At 05:00 on Sunday.
     - cron: "0 5 * * 0"

--- a/README.orig.adoc
+++ b/README.orig.adoc
@@ -79,7 +79,7 @@ this is often shown as `my-site` in the CheckMK documentation examples.
 [source,yaml]
 ----
 checkmk_server_download_checksum: [OS-specific, see /defaults directory]
-checkmk_server_version: "2.0.0p26"
+checkmk_server_version: "2.0.0p27"
 ----
 Version of CheckMK RAW edition to install.
 

--- a/__scripts/ci.py
+++ b/__scripts/ci.py
@@ -7,18 +7,25 @@ import getpass
 import json
 import os
 import platform
+import shutil
+from html import escape
 from pathlib import Path
 from time import sleep
 from typing import Callable
+from typing import Final
 from typing import Iterator
 from urllib import request
 from urllib.error import URLError
 
 import yaml
 from github import Github
+from github import UnknownObjectException
+from github.Issue import Issue
+from github.Label import Label
 from github.PullRequest import PullRequest
 from github.Repository import Repository
 from github.Tag import Tag
+from semver import VersionInfo
 
 from .utils import add_argparse_silent_option
 from .utils import add_argparse_verbosity_option
@@ -28,12 +35,33 @@ from .utils import generate_yaml
 from .utils import get_checkmk_raw_tags_since
 from .utils import init_logger
 from .utils import logger
+from .utils import on_rm_error
 from .utils import replace_text_between
 
 SERVER_MASTER_BRANCH: str = "master"
 SERVER_PR_BRANCH: str = "checkmk_server_version-autoupdate"
 AGENT_MASTER_BRANCH: str = "master"
 AGENT_PR_BRANCH: str = "checkmk_agent_version-autoupdate"
+
+SERVER_REPO_FILES: list[str] = ["defaults/main.yml", "README.orig.adoc"]
+AGENT_REPO_FILES: list[str] = ["defaults/main.yml", "README.orig.adoc"]
+
+FIND_MISSING_RELEASE_BASE_TITLE: Final[
+    str
+] = "[check-new-versions.yml] Please create a new release"
+
+__script_executor_origin = "(could not resolve ip address location)"
+try:
+    _origin = json.load(
+        request.urlopen("https://geolocation-db.com/json/&position=true")
+    )
+    __script_executor_origin = _origin["city"]
+except (URLError, json.JSONDecodeError):
+    pass
+SCRIPT_MSG: str = (
+    ":robot: *Authored by `__scripts/ci.py` python script "
+    f"on {platform.node()} by {getpass.getuser()} from {__script_executor_origin}* "
+)
 
 
 def unidiff_output(expected: str, actual: str):
@@ -48,7 +76,7 @@ def unidiff_output(expected: str, actual: str):
 
 def clone_repo_and_checkout_branch(
     repo: Repository, repo_path: Path, branch: str
-) -> str:
+) -> tuple[str, Callable[..., object]]:
     if not repo_path.joinpath(".git").exists():
         execute(["git", "clone", repo.clone_url], repo_path.parent)
     if "AUTO_UPDATE_PAT" in os.environ:
@@ -77,20 +105,200 @@ def clone_repo_and_checkout_branch(
     if _git_branch_before != branch:
         execute(["git", "fetch"], repo_path)
         execute(["git", "checkout", branch], repo_path)
-    return _git_branch_before
 
-
-def checkout_pristine_pr_branch(
-    repo_path: Path, pr_branch: str, before_branch: str, files: list[str]
-) -> Callable[..., object]:
     def atexit_handler() -> None:
         logger.notice(
             "The program terminated unexpectedly! "
             f"Checking out the {repo_path.name} branch "
             "we were previously on..."
         )
-        execute(["git", "checkout", before_branch], repo_path)
+        execute(["git", "checkout", _git_branch_before], repo_path)
 
+    atexit.register(atexit_handler)
+
+    return _git_branch_before, atexit_handler
+
+
+def get_prefilled_new_release_url(
+    repo: Repository,
+    master: str,
+    repo_other: Repository,
+    new_version: str,
+    new_tag: str,
+    new_tag_other: str,
+):
+    # note: 'body' param must come last to be able to make additions
+    return (
+        f"{repo.html_url}/releases/new"
+        f"?tag={escape(new_tag)}"
+        f"&target={escape(master)}"
+        f"&title=update%20default%20to%20{escape(new_version)}"
+        f"&body=Accompanying%20%60{escape(repo_other.name)}%60%20release%3A%20"
+        f"%5B{escape(new_tag_other)}%5D"
+        f"%28https%3A%2F%2Fgithub.com%2FJonasPammer%2Fansible-role-checkmk_server"
+        f"%2Freleases%2Ftag%2F{escape(new_tag_other)}%29"
+    )
+
+
+def close_missing_release_issues(
+    repo: Repository,
+    latest_released_role_tag: Tag,
+    current_checkmk_version: str,
+    dry_run: bool,
+):
+    for issue in repo.get_issues(state="open"):
+        if FIND_MISSING_RELEASE_BASE_TITLE not in issue.title:
+            continue
+        if dry_run:
+            logger.info(
+                f"Would've closed {issue} of {repo} with a comment "
+                "as the default checkmk version in the latest role "
+                "release matches the current version! "
+            )
+            continue
+        logger.info(
+            f"Closing {issue} of {repo} as the default checkmk version "
+            "in the latest role release matches the current version! "
+        )
+        issue.create_comment(
+            "Closing this Issue as the default checkmk version "
+            f"defined in the latest release ([{latest_released_role_tag.name}]"
+            f"({latest_released_role_tag.commit.html_url})) "
+            f"now matches the current check version of {current_checkmk_version}! "
+            f"\n\n {SCRIPT_MSG}"
+        )
+        issue.edit(state="closed")
+
+
+def create_or_update_missing_release_issue(
+    repo: Repository,
+    latest_released_role_tag: Tag,
+    latest_released_checkmk_version: str,
+    current_checkmk_version: str,
+    next_role_tag_create_url: str,
+    dry_run: bool,
+):
+    GENERAL_BODY = (
+        "The default checkmk version has recently been updated "
+        f"from {latest_released_checkmk_version} "
+        f"(in [{latest_released_role_tag.name}]"
+        f"({latest_released_role_tag.commit.html_url})) "
+        f"to {current_checkmk_version}, "
+        "but no new GitHub release/tag has been created for it. "
+    )
+    BODY_TIP = (
+        "\n\n"
+        "Automated Version Updating is halted until a new version is released. "
+        "Please use the following link as a starting point "
+        "for creating the new release: \n"
+        f"> {next_role_tag_create_url}"
+    )
+    ISSUE_BODY = GENERAL_BODY + BODY_TIP
+    logger.error(ISSUE_BODY.replace("\n\n", ""))
+    ISSUE_BODY += f"\n\n {SCRIPT_MSG}"
+
+    found_issue: Issue | None = None
+    for issue in repo.get_issues(state="all"):
+        if (
+            FIND_MISSING_RELEASE_BASE_TITLE in issue.title
+            and current_checkmk_version in issue.title
+        ):
+            if found_issue is not None:
+                logger.error(
+                    "Found more than one "
+                    f"'missing release {current_checkmk_version}' issues?! "
+                    f"{issue} {found_issue}"
+                )
+                exit(1)
+            found_issue = issue
+
+    ACTUAL_ISSUE_TITLE = (
+        FIND_MISSING_RELEASE_BASE_TITLE + f" for {current_checkmk_version}"
+    )
+    __issue_params = {"title": ACTUAL_ISSUE_TITLE, "body": ISSUE_BODY}
+    if found_issue is None:
+        if not dry_run:
+            found_issue = repo.create_issue(
+                *__issue_params, assignee=repo.owner, labels=[]
+            )
+            logger.info(
+                "Created 'missing release issue' "
+                f"{found_issue.html_url} ({__issue_params})"
+            )
+        else:
+            logger.info(f"Would've created 'missing release issue' {__issue_params}")
+    else:
+        __issue_change_log = (
+            "\n"
+            + unidiff_output(found_issue.title, ACTUAL_ISSUE_TITLE)
+            + "\n"
+            + unidiff_output(found_issue.body, ISSUE_BODY)
+        )
+        if not dry_run:
+            logger.info(
+                "Editing 'missing release issue' "
+                f"{found_issue.html_url}... {__issue_change_log}"
+            )
+            found_issue.edit(
+                *__issue_params,
+                assignee=repo.owner,
+                state="open",
+                labels=[],
+            )
+        else:
+            logger.info(
+                "Would've edited 'missing release issue' "
+                f"{found_issue.html_url} {__issue_change_log}"
+            )
+
+    # close PRs
+    open_version_change_prs: list[PullRequest] = []
+    for pr in repo.get_pulls():
+        pr_files = pr.get_files()
+        for file in filter(
+            lambda f: any(s == f.filename for s in SERVER_REPO_FILES), pr_files
+        ):
+            if "version: " in file.patch:
+                open_version_change_prs.append(pr)
+                break  # file loop
+
+    for pr in open_version_change_prs:
+        if dry_run:
+            logger.info(
+                f"Would've closed {pr} of {repo} because of "
+                "release and current version mismatch error..."
+            )
+            continue
+        logger.info(
+            f"Closing {pr} of {repo} as the default checkmk version "
+            f"in the latest role release does not match the current version! "
+            f"May reopen again when {found_issue.html_url} is resolved. "
+        )
+        labels: list[Label | str] = pr.labels
+        if not any("do-not-merge" == str(label) for label in labels):
+            try:
+                labels.append(repo.get_label("do-not-merge"))
+            except UnknownObjectException:
+                logger.warning(f"Could not find 'do-not-merge' label in {repo}.")
+        _opt = "**Please re-open this PR if said Issue has been resolved.**"
+        if ":robot:" not in pr.body:
+            _opt = (
+                "*This PR will re-open itself automatically on a new ci.py run "
+                "once said Issue has been resolved!*"
+            )
+        pr.set_labels(*labels)
+        pr.create_issue_comment(
+            GENERAL_BODY + "\n\n"
+            "Closing this pull request until "
+            f"#{found_issue.number} has been resolved! {_opt}"
+            f"\n\n{SCRIPT_MSG}"
+        )
+        pr.edit(state="closed")
+
+
+def checkout_pristine_pr_branch(
+    repo_path: Path, pr_branch: str, before_branch: str, files: list[str]
+) -> None:
     _git_status_before = execute(["git", "status", "--porcelain"], repo_path)
     if any(s in _git_status_before for s in files):
         logger.error("Working directory is not clean! Aborting...")
@@ -116,12 +324,10 @@ def checkout_pristine_pr_branch(
 
     execute(["git", "fetch"], repo_path)
     execute(["git", "checkout", pr_branch], repo_path)
-    atexit.register(atexit_handler)
 
     execute(["git", "reset"], repo_path)
     for f in files:
         execute(["git", "checkout", "HEAD", "--", f], repo_path)
-    return atexit_handler
 
 
 def commit_push_and_checkout_before(
@@ -148,16 +354,47 @@ def commit_push_and_checkout_before(
             ["git", "push", "--force", "--set-upstream", "origin", pr_branch],
             repo_path,
         )
+
+    # eliminate windows bug
+    for f in files:
+        execute(["git", "add", f], repo_path)
+
     logger.verbose(f"Checking out previous branch of {repo_path.name} again..")
     execute(["git", "checkout", before_branch], repo_path)
 
     atexit.unregister(atexit_handler)
 
 
+def get_sorted_semver_tags(repo: Repository) -> list[tuple[Tag, VersionInfo]]:
+    """Query given repository and return list of tags that represent valid
+    semantic versions strings.
+
+    :param repo:
+        `GitHub.Repository` Object used to query tags from GitHub's API
+    :return:
+        A list of tuples in which the first (0) item is the `github.Tag`
+        and the second (1) item is a `VersionInfo` object that has
+        been crufted by using the tag's name.
+        The list is sorted so the latest version will always be on top ([0]).
+    """
+    tags_since: list[tuple[Tag, VersionInfo]] = []
+    for tag in repo.get_tags():
+        # https://galaxy.ansible.com/docs/contributing/version.html
+        if not VersionInfo.isvalid(tag.name):
+            logger.debug(
+                f"Tag '{tag.name}' of '{repo.name}' does not match SemVer. "
+                "Skipping.."
+            )
+            continue
+        tags_since.append((tag, VersionInfo.parse(tag.name)))
+    # sort using VersionInfo's dunders
+    return sorted(tags_since, key=lambda tup: tup[1], reverse=True)
+
+
 def find_pr(
     repo: Repository, branch: str, loose_str: str, next_checkmk_server_version: Tag
 ) -> PullRequest | None:
-    pull_requests = repo.get_pulls()
+    pull_requests = repo.get_pulls(state="open")
     found_pr: PullRequest | None = None
     for pr in pull_requests:
         if pr.head.ref == branch and loose_str in pr.title:
@@ -187,7 +424,40 @@ def write_and_log(file: Path, old_content: str, new_content: str):
     file.write_text(new_content, encoding="utf-8")
 
 
-def _make_server_changes(server_repo_path: Path, next_checkmk_server_version: Tag):
+def _get_server_change_notes(
+    default_yml_contents_old: str, default_yml_contents_new: str
+) -> list[str]:
+    _retv: list[str] = []
+    parsed_default_yml_contents_old = yaml.safe_load(default_yml_contents_old)
+    parsed_default_yml_contents_new = yaml.safe_load(default_yml_contents_new)
+
+    _old_checksums = parsed_default_yml_contents_old[
+        "_checkmk_server_download_checksum"
+    ]
+    _new_checksums = parsed_default_yml_contents_new[
+        "_checkmk_server_download_checksum"
+    ]
+
+    for key, checksum_new in _new_checksums.items():
+        checksum_old = _old_checksums.get(key, None)
+        if checksum_new is not None and checksum_old is None:
+            _retv.append(f"CheckMk Added support for {key}")
+        elif checksum_new is None and checksum_old is not None:
+            _retv.append(f"CheckMk dropped support for {key}")
+        elif checksum_new is not None and checksum_old == "None":
+            _retv.append(f"Added checksum for {key}")
+
+    for key, checksum_old in _old_checksums.items():
+        checksum_new = _new_checksums.get(key, "None")
+        if checksum_old is None and checksum_new == "None":
+            _retv.append(f"Dropped support for {key} by removing checksum")
+
+    return _retv
+
+
+def _make_server_changes(
+    server_repo_path: Path, next_checkmk_server_version: Tag
+) -> list[str]:
     default_yml: Path = server_repo_path.joinpath("defaults/main.yml")
     default_yml_contents_old: str = default_yml.read_text(encoding="utf8")
     default_yml_contents_new: str = replace_text_between(
@@ -211,6 +481,7 @@ def _make_server_changes(server_repo_path: Path, next_checkmk_server_version: Ta
         next_checkmk_server_version.name.replace("v", ""),
     )
     write_and_log(readme, readme_contents_old, readme_contents_new)
+    return _get_server_change_notes(default_yml_contents_old, default_yml_contents_new)
 
 
 def _make_agent_changes(agent_repo_path: Path, next_checkmk_server_version: Tag):
@@ -252,14 +523,17 @@ def main() -> None:
     args = parser.parse_args()
     init_logger(args.verbose, args.silent)
 
-    _login_or_token = None if args.dry_run else os.environ["GITHUB_TOKEN"]
+    _login_or_token = os.environ["GITHUB_TOKEN"]
     github_api: Github = Github(_login_or_token)
 
     server_repo: Repository = github_api.get_repo(
         "JonasPammer/ansible-role-checkmk_server"
     )
     server_repo_path: Path = Path.cwd()
-    server_local_git_branch_before = clone_repo_and_checkout_branch(
+    (
+        server_local_git_branch_before,
+        server_atexit_handler,
+    ) = clone_repo_and_checkout_branch(
         server_repo, server_repo_path, SERVER_MASTER_BRANCH
     )
 
@@ -267,9 +541,12 @@ def main() -> None:
         "JonasPammer/ansible-role-checkmk_agent"
     )
     agent_repo_path: Path = server_repo_path.joinpath("__scripts", agent_repo.name)
-    agent_local_git_branch_before = clone_repo_and_checkout_branch(
-        agent_repo, agent_repo_path, AGENT_MASTER_BRANCH
-    )
+    if agent_repo_path.exists():
+        shutil.rmtree(agent_repo_path, onerror=on_rm_error)
+    (
+        agent_local_git_branch_before,
+        agent_atexit_handler,
+    ) = clone_repo_and_checkout_branch(agent_repo, agent_repo_path, AGENT_MASTER_BRANCH)
 
     server_defaults_yml: Path = server_repo_path.joinpath("defaults/main.yml")
     current_checkmk_server_version = yaml.safe_load(
@@ -281,11 +558,16 @@ def main() -> None:
     )["checkmk_agent_version"]
 
     if current_checkmk_server_version != current_checkmk_agent_version:
+        # TODO this should create an issue tbh
         logger.fatal(
             "Version mismatch between current checkmk_server_version "
             "and checkmk_agent_version!! Aborting, please fix.."
         )
         exit(1)
+    logger.verbose(
+        f"{server_repo.name} and {agent_repo.name} have "
+        "the same checkmk version! Continuing.."
+    )
 
     tags_since = get_checkmk_raw_tags_since(current_checkmk_server_version, github_api)
     if len(tags_since) == 0:
@@ -309,23 +591,98 @@ def main() -> None:
         f"Next: '{next_checkmk_server_version.name}'"
     )
 
-    _script_executor_origin = "(could not resolve ip address location)"
-    try:
-        _origin = json.load(
-            request.urlopen("https://geolocation-db.com/json/&position=true")
+    server_role_tags: Final[list[tuple[Tag, VersionInfo]]] = get_sorted_semver_tags(
+        server_repo
+    )
+    agent_role_tags: Final[list[tuple[Tag, VersionInfo]]] = get_sorted_semver_tags(
+        agent_repo
+    )
+
+    latest_released_checkmk_server_version: str = yaml.safe_load(
+        server_repo.get_contents(
+            "defaults/main.yml", ref=server_role_tags[0][0].commit.sha
+        ).decoded_content
+    )["checkmk_server_version"]
+
+    latest_released_checkmk_agent_version: str = yaml.safe_load(
+        agent_repo.get_contents(
+            "defaults/main.yml", ref=agent_role_tags[0][0].commit.sha
+        ).decoded_content
+    )["checkmk_agent_version"]
+
+    next_server_role_tag_version: VersionInfo = server_role_tags[0][1].bump_patch()
+    next_agent_role_tag_version: VersionInfo = agent_role_tags[0][1].bump_patch()
+    next_server_role_tag_create_url: str = get_prefilled_new_release_url(
+        server_repo,
+        SERVER_MASTER_BRANCH,
+        repo_other=agent_repo,
+        new_version=next_checkmk_server_version.name,
+        new_tag=str(next_server_role_tag_version),
+        new_tag_other=str(next_agent_role_tag_version),
+    )
+    next_agent_role_tag_create_url: str = get_prefilled_new_release_url(
+        agent_repo,
+        AGENT_MASTER_BRANCH,
+        repo_other=server_repo,
+        new_version=next_checkmk_server_version.name,
+        new_tag=str(next_agent_role_tag_version),
+        new_tag_other=str(next_server_role_tag_version),
+    )
+
+    _exit: bool = False
+    if latest_released_checkmk_server_version != current_checkmk_server_version:
+        create_or_update_missing_release_issue(
+            server_repo,
+            latest_released_role_tag=server_role_tags[0][0],
+            latest_released_checkmk_version=latest_released_checkmk_server_version,
+            current_checkmk_version=current_checkmk_server_version,
+            next_role_tag_create_url=next_server_role_tag_create_url,
+            dry_run=True,
         )
-        _script_executor_origin = _origin["city"]
-    except (URLError, json.JSONDecodeError):
-        pass
-    SCRIPT_MSG: str = (
-        ":robot: Authored by `__scripts/ci.py` python script "
-        f"on {platform.node()} by {getpass.getuser()} from {_script_executor_origin} "
+        _exit = True
+    else:
+        close_missing_release_issues(
+            server_repo,
+            server_role_tags[0][0],
+            current_checkmk_server_version,
+            dry_run=True,
+        )
+
+    if latest_released_checkmk_agent_version != current_checkmk_agent_version:
+        create_or_update_missing_release_issue(
+            server_repo,
+            latest_released_role_tag=agent_role_tags[0][0],
+            latest_released_checkmk_version=latest_released_checkmk_agent_version,
+            current_checkmk_version=current_checkmk_agent_version,
+            next_role_tag_create_url=next_agent_role_tag_create_url,
+            dry_run=True,
+        )
+        exit(1)
+    else:
+        close_missing_release_issues(
+            agent_repo,
+            agent_role_tags[0][0],
+            current_checkmk_agent_version,
+            dry_run=True,
+        )
+    if _exit:
+        exit(1)
+    del _exit
+    logger.verbose(
+        "The checkmk version found in the latest release of both "
+        f"{server_repo.name} and {agent_repo.name} match with the "
+        "respective currently cloned master one. Continuing..."
     )
-    PR_NOTE = (
-        "**This PR should result in the release of a new minor version for this role**!"
+
+    _PR_NOTE1_BASE = (
+        "**This PR should result in the release of a new minor version "
+        "for this role**! "
+        "Please use the following link as a starting point "
+        "for creating the new release: "
     )
+    PR_NOTE2 = ""
     if len(tags_since) > 1:
-        PR_NOTE += (
+        PR_NOTE2 += (
             "\n\n"
             f"NOTE: There have been **{len(tags_since)}** new versions since "
             f"{current_checkmk_server_version}. "
@@ -348,27 +705,38 @@ def main() -> None:
         f"from {current_checkmk_server_version} "
         f"to {next_checkmk_server_version.name} :arrow_up:"
     )
+    SERVER_PR_NOTE1 = _PR_NOTE1_BASE + "\n> " + next_server_role_tag_create_url
     AGENT_COMMIT_TITLE: str = (
         "refactor: update default checkmk_agent_version "
         f"from {current_checkmk_agent_version} "
         f"to {next_checkmk_server_version.name} :arrow_up:"
     )
-    SERVER_PR_BODY: str = f"{SCRIPT_MSG} \n\n {COMMIT_DESCRIPTION} \n\n {PR_NOTE}"
-    AGENT_PR_BODY: str = SERVER_PR_BODY
+    AGENT_PR_NOTE1 = _PR_NOTE1_BASE + "\n> " + next_agent_role_tag_create_url
+    SERVER_PR_BODY: str = (
+        f"{SCRIPT_MSG} \n\n {COMMIT_DESCRIPTION} \n\n" f"{SERVER_PR_NOTE1} {PR_NOTE2}"
+    )
+    AGENT_PR_BODY: str = (
+        f"{SCRIPT_MSG} \n\n {COMMIT_DESCRIPTION} \n\n" f"{AGENT_PR_NOTE1} {PR_NOTE2}"
+    )
 
-    server_repo_files: list[str] = ["defaults/main.yml", "README.orig.adoc"]
-    server_atexit_handler = checkout_pristine_pr_branch(
+    checkout_pristine_pr_branch(
         repo_path=server_repo_path,
         pr_branch=SERVER_PR_BRANCH,
         before_branch=server_local_git_branch_before,
-        files=server_repo_files,
+        files=SERVER_REPO_FILES,
     )
-    _make_server_changes(server_repo_path, next_checkmk_server_version)
+    server_change_notes: list[str] = _make_server_changes(
+        server_repo_path, next_checkmk_server_version
+    )
+    if len(server_change_notes) != 0:
+        next_server_role_tag_create_url += escape("NOTES: \n")
+        for note in server_change_notes:
+            next_server_role_tag_create_url += escape(f"* {note} \n")
     commit_push_and_checkout_before(
         repo_path=server_repo_path,
         pr_branch=SERVER_PR_BRANCH,
         before_branch=server_local_git_branch_before,
-        files=server_repo_files,
+        files=SERVER_REPO_FILES,
         atexit_handler=server_atexit_handler,
         dry_run=args.dry_run,
         commit_title=SERVER_COMMIT_TITLE,
@@ -376,19 +744,18 @@ def main() -> None:
         description=COMMIT_DESCRIPTION,
     )
 
-    agent_repo_files: list[str] = ["defaults/main.yml", "README.orig.adoc"]
-    agent_atexit_handler = checkout_pristine_pr_branch(
+    checkout_pristine_pr_branch(
         repo_path=agent_repo_path,
         pr_branch=AGENT_PR_BRANCH,
         before_branch=agent_local_git_branch_before,
-        files=agent_repo_files,
+        files=AGENT_REPO_FILES,
     )
     _make_agent_changes(agent_repo_path, next_checkmk_server_version)
     commit_push_and_checkout_before(
         repo_path=agent_repo_path,
         pr_branch=AGENT_PR_BRANCH,
         before_branch=agent_local_git_branch_before,
-        files=agent_repo_files,
+        files=AGENT_REPO_FILES,
         atexit_handler=agent_atexit_handler,
         dry_run=args.dry_run,
         commit_title=AGENT_COMMIT_TITLE,
@@ -402,14 +769,20 @@ def main() -> None:
         "refactor: update default checkmk_server_version",
         next_checkmk_server_version,
     )
-    if not args.dry_run and found_server_pr is None:
-        found_server_pr = server_repo.create_pull(
-            title=SERVER_COMMIT_TITLE,
-            body=SERVER_PR_BODY,
-            head=SERVER_PR_BRANCH,
-            base=SERVER_MASTER_BRANCH,
-        )
-        logger.info(f"Created {server_repo.name} PR: {found_server_pr.html_url}")
+    if found_server_pr is None:
+        __create_server_pull_params = {
+            "title": SERVER_COMMIT_TITLE,
+            "body": SERVER_PR_BODY,
+            "head": SERVER_PR_BRANCH,
+            "base": SERVER_MASTER_BRANCH,
+        }
+        if not args.dry_run:
+            found_server_pr = server_repo.create_pull(*__create_server_pull_params)
+            logger.info(f"Created {server_repo.name} PR: {found_server_pr.html_url}")
+        else:
+            logger.info(
+                f"Would've created {agent_repo.name} PR: {__create_server_pull_params}"
+            )
 
     found_agent_pr = find_pr(
         agent_repo,
@@ -417,32 +790,66 @@ def main() -> None:
         "refactor: update default checkmk_agent_version",
         next_checkmk_server_version,
     )
-    if not args.dry_run and found_agent_pr is None:
-        found_agent_pr = agent_repo.create_pull(
-            title=AGENT_COMMIT_TITLE,
-            body=AGENT_PR_BODY,
-            head=AGENT_PR_BRANCH,
-            base=AGENT_MASTER_BRANCH,
-        )
-        logger.info(f"Created {agent_repo.name} PR: {found_agent_pr.html_url}")
+    if found_agent_pr is None:
+        __create_agent_pull_params = {
+            "title": AGENT_COMMIT_TITLE,
+            "body": AGENT_PR_BODY,
+            "head": AGENT_PR_BRANCH,
+            "base": AGENT_MASTER_BRANCH,
+        }
+        if not args.dry_run:
+            found_agent_pr = agent_repo.create_pull(*__create_agent_pull_params)
+            logger.info(f"Created {agent_repo.name} PR: {found_agent_pr.html_url}")
+        else:
+            logger.info(
+                f"Would've created {agent_repo.name} PR: {__create_agent_pull_params}"
+            )
 
-    if not args.dry_run and found_server_pr is not None:
+    if found_server_pr is not None:
         if found_agent_pr is not None:
             SERVER_PR_BODY += (
                 "\n\n---\n"
                 f"Accompanying `{agent_repo.name}` PR: " + found_agent_pr.html_url
             )
-        found_server_pr.edit(
-            title=SERVER_COMMIT_TITLE, body=SERVER_PR_BODY, state="open"
+        __server_pr_change_log = (
+            "\n"
+            + unidiff_output(found_server_pr.title, SERVER_COMMIT_TITLE)
+            + "\n"
+            + unidiff_output(found_server_pr.body, SERVER_PR_BODY)
         )
+        if not args.dry_run:
+            logger.info(
+                f"Editing {found_server_pr.html_url}... {__server_pr_change_log}"
+            )
+            found_server_pr.edit(
+                title=SERVER_COMMIT_TITLE, body=SERVER_PR_BODY, state="open"
+            )
+        else:
+            logger.info(
+                f"Would've edited {found_server_pr.html_url} {__server_pr_change_log}"
+            )
 
-    if not args.dry_run and found_agent_pr is not None:
+    if found_agent_pr is not None:
         if found_server_pr is not None:
             AGENT_PR_BODY += (
                 "\n\n---\n"
                 f"Accompanying `{server_repo.name}` PR: " + found_server_pr.html_url
             )
-        found_agent_pr.edit(title=AGENT_COMMIT_TITLE, body=AGENT_PR_BODY, state="open")
+        __agent_pr_change_log = (
+            "\n"
+            + unidiff_output(found_agent_pr.title, AGENT_COMMIT_TITLE)
+            + "\n"
+            + unidiff_output(found_agent_pr.body, AGENT_PR_BODY)
+        )
+        if not args.dry_run:
+            logger.info(f"Editing {found_agent_pr.html_url}... {__agent_pr_change_log}")
+            found_agent_pr.edit(
+                title=AGENT_COMMIT_TITLE, body=AGENT_PR_BODY, state="open"
+            )
+        else:
+            logger.info(
+                f"Would've edited {found_agent_pr.html_url} {__agent_pr_change_log}"
+            )
 
 
 if __name__ == "__main__":

--- a/__scripts/requirements.in
+++ b/__scripts/requirements.in
@@ -1,5 +1,6 @@
 PyGitHub>=1,<2
 pyyaml
 rich
+semver
 types-PyYAML
 verboselogs

--- a/__scripts/requirements.txt
+++ b/__scripts/requirements.txt
@@ -32,6 +32,8 @@ requests==2.28.1
     # via pygithub
 rich==12.5.1
     # via -r __scripts/requirements.in
+semver==2.13.0
+    # via -r __scripts/requirements.in
 types-pyyaml==6.0.11
     # via -r __scripts/requirements.in
 typing-extensions==4.3.0

--- a/__scripts/utils.py
+++ b/__scripts/utils.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import os
 import pathlib
+import stat
 import subprocess
 from argparse import ArgumentParser
 from functools import lru_cache
@@ -359,3 +360,9 @@ def execute(
             f"See above for more information."
         )
         raise ex
+
+
+def on_rm_error(func, path, exc_info):
+    # from https://stackoverflow.com/a/4829285
+    os.chmod(path, stat.S_IWRITE)
+    os.unlink(path)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,18 +19,18 @@ checkmk_server_install_cache_valid_time: "3600"
 # ===== BEGIN generate_yaml MANAGED SECTION
 
 _checkmk_server_download_checksum:
-  CentOS_7: sha1:87affa588da9c56b6a80ac425a7d4f3ab1d9028c
-  CentOS_8: sha1:cb3a4b8bf35ba6f939710cf4acfb9b7da34c1f45
-  Debian_bullseye: sha1:c896a0cdfa2a648229e160c1660a94ba445c5e50
-  Debian_buster: sha1:7213547a2f5e336b31a057ef0773f5a88ed42b0d
-  Debian_stretch: sha1:3fc6bc7f2c71dac3240b3cf2f5ec5523a4f2457d
-  Ubuntu_bionic: sha1:b08c77f31796754af0942e0100fe58675b2b8b54
-  Ubuntu_focal: sha1:cce6a669ad56c8a7cbb47a9f50ac31964fe4c96f
-  Ubuntu_hirsute: sha1:9947418875f973e2015619f7c3bedd7c7b1c393b
-  Ubuntu_impish: sha1:6995f3fd86fa894071ebef05108a30568b15a251
-  Ubuntu_jammy: sha1:03902a04795ea5a9d0a5fd71b8d933f8956a4e1e
-  Ubuntu_xenial: sha1:c5555ed1cb2dad304a07bc4a326e11d7f5349930
-checkmk_server_version: 2.0.0p26
+  CentOS_7: sha1:a5a6ebe3431f814fa24d2e9c4a6e742a408b5658
+  CentOS_8: sha1:d565f8ab19b67a2e8d62136be7ebeeb80d85e5c4
+  Debian_bullseye: sha1:8e82f2fc3692b3756b44d2a64221b754ee9eebc6
+  Debian_buster: sha1:fcca752dd4956943f92a72d492f2991e583b664a
+  Debian_stretch: sha1:0bf3ad00f06fbc591bb8908b30dd8cdba0f2dd33
+  Ubuntu_bionic: sha1:8de78553aa1933ff7b7ca4d0594d07550ff29316
+  Ubuntu_focal: sha1:9334d58a775db6db4cc31bcdc13c97adae0add18
+  Ubuntu_hirsute: sha1:468b16647ec3262f761279b22db3f22031f321be
+  Ubuntu_impish: sha1:9db1330d8654bb2071d2cf1fae0d2a6c4d6635a9
+  Ubuntu_jammy: sha1:a4a8899e83828aef985ae8e212ec9448cf99852d
+  Ubuntu_xenial: sha1:fabe141626d02730d37c10058559309b17ca4507
+checkmk_server_version: 2.0.0p27
 
 # ===== END generate_yaml MANAGED SECTION
 checkmk_server_download_checksum: "{{


### PR DESCRIPTION
:robot: *Authored by `__scripts/ci.py` python script on fv-az180-788 by runner from None*  

 *Release Date of v2.0.0p27: 2022-07-19*
*GitHub Compare URL (for the interested):* https://github.com/tribe29/checkmk/compare/v2.0.0p26...v2.0.0p27

 

**This PR should result in the release of a new minor version for this role**! Please use the following link as a starting point for creating the new release: 
> https://github.com/JonasPammer/ansible-role-checkmk_server/releases/new?tag=2.0.3&target=master&title=update%20default%20to%20v2.0.0p27&body=Accompanying%20%60ansible-role-checkmk_agent%60%20release%3A%20%5B1.0.2%5D%28https%3A%2F%2Fgithub.com%2FJonasPammer%2Fansible-role-checkmk_server%2Freleases%2Ftag%2F1.0.2%29 

NOTE: There have been **12** new versions since 2.0.0p26. After this PR has been merged, the github workflow will run again and a new PR will open semi-immideally. Please ensure to create a proper tag/release for **every** merged ci.py PR.

---
Accompanying `ansible-role-checkmk_agent` PR: https://github.com/JonasPammer/ansible-role-checkmk_agent/pull/9