### PR TITLE
ci: exclude pip-compile'd files from renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,7 +30,7 @@
   configMigration: true,
   lockFileMaintenance: { enabled: true },
   stabilityDays: 7,
-
+  ignorePaths: ["__scripts/requirements*.txt"],
   packageRules: [
     {
       matchPackagePatterns: ["eslint"],


### PR DESCRIPTION
Fixes #96

<!-- Insert Description here, if any. -->

## **Pull Request Checklist**

- [ ] I am a nice guy <!-- the 'too long; did not read;' of the CODE_OF_CONDUCT.md -->
- [x] This pull request and its commits address only a single concern
- [ ] Documentation has been altered or extended appropriately

- [ ] I have followed [JonasPammer's Ansible Role Development Guidelines](https://github.com/JonasPammer/cookiecutter-ansible-role/blob/master/ROLE_DEVELOPMENT_GUIDELINES.adoc)

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
